### PR TITLE
[FDV-548] Create a CI workflow with Autoware Foundation's actions

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,0 +1,167 @@
+# It directly uses autowarefoundation/autoware-github-actions for now
+# but may change using Futu-reADS/autoware-github-actions
+# that will be forked or mirrored from the original
+
+name: build-and-test
+
+on:
+  push:
+  ###   - branches: [ "main" ]
+  ### schedule:
+  ###   - cron: 0 0 * * *
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    if: (github.event_name == 'push' && github.event.before != '0000000000000000000000000000000000000000') ||
+        (github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-22.04
+    container: ${{ matrix.container }}
+    strategy:
+      fail-fast: false
+      # Currently, only for ROS 2 Humble
+      matrix:
+        rosdistro:
+          - humble
+        include:
+          - rosdistro: humble
+            container: ros:humble
+            build-depends-repos: build_depends.repos
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Show disk space before the tasks
+        run: df -h
+
+      - name: Remove exec_depend
+        uses: autowarefoundation/autoware-github-actions/remove-exec-depend@v1
+
+      - name: Get self packages
+        id: get-self-packages
+        uses: autowarefoundation/autoware-github-actions/get-self-packages@v1
+
+      # Added for FUTU-RE
+      - name: Check build_depends.repos
+        id: check-file
+        run: |
+          if [ -f build_depends.repos ]; then
+            echo "build_depends_repos=true" >> $GITHUB_OUTPUT
+          else
+            echo "build_depends_repos=false" >> $GITHUB_OUTPUT
+          fi
+
+      # Added for FUTU-RE
+      - name: Copy our latest autoware.repos
+        if: ${{ steps.check-file.outputs.build_depends_repos != 'true' }}
+        uses: actions/checkout@v4
+        with:
+          repository: Futu-reADS/autoware.FTD
+          sparse-checkout: |
+            autoware.repos
+          sparse-checkout-cone-mode: false
+          path: autoware.FTD
+      - run: |
+          cd autoware.FTD
+          cp autoware.repos ../build_depends.repos
+          # Do not process here afterwards
+          touch AMENT_IGNORE COLCON_IGNORE
+
+      # Added for FUTU-RE
+      - name: Install additional packages
+        run: |
+          # Install dependent packages
+          sudo apt-get update -qy
+          sudo apt-get install -y \
+            ros-humble-autoware-common-msgs \
+            libunwind-dev \
+            apt-utils
+
+      # Added for FUTU-RE
+      - name: Pass ROS environment variables to the subsequent steps
+        run: |
+          # It runs on sh but not bash
+          . /opt/ros/${{ matrix.rosdistro }}/setup.sh
+          env | grep -E -e '^ROS_' -e '/ros/' >> "$GITHUB_ENV"
+
+      # Added for FUTU-RE
+      - name: Set Git credential for private repos
+        run: |
+          git config --global credential.helper store
+          echo "url=${{ github.server_url }}" > ~/url-username-password.txt
+          echo "username=oku-s" >> ~/url-username-password.txt
+          echo "password=${{ secrets.UNITTEST_WORKFLOW_TOKEN }}" >> ~/url-username-password.txt
+          git credential approve < ~/url-username-password.txt
+
+      # Added for FUTU-RE
+      # NOTE:
+      # This step might be able to be removed
+      # by tuning package.xml and/or autoware.repos appropriately
+      # so that colcon can find the following modules
+      - name: Build and install dependent modules
+        run: |
+          mkdir -p src_tmp
+          cat build_depends.repos \
+          | sed 's/git@github.com:/https:\/\/github.com\//' \
+          | vcs import --shallow --recursive src_tmp
+          sudo rosdep init || true
+          rosdep update
+          rosdep install --from-paths src_tmp --ignore-src -r -y -t build
+          for PKG in \
+              autoware_auto_msgs \
+              autoware_auto_system_msgs \
+              autoware_adapi_v1_msgs \
+              tier4_control_msgs \
+              tier4_system_msgs \
+              autoware_bridge_msgs \
+              ftd_master_msgs \
+              ; do
+            find src_tmp \
+              -type f \
+              -path "*/$PKG/CMakeLists.txt" \
+              -execdir pwd \; \
+            | {
+              read -r WORKDIR &&
+              cd "$WORKDIR" &&
+              cmake . &&
+              make &&
+              sudo make install
+            }
+          done
+          sudo ldconfig
+          sudo rm -rf src_tmp
+
+      - name: Build
+        if: ${{ steps.get-self-packages.outputs.self-packages != '' }}
+        uses: autowarefoundation/autoware-github-actions/colcon-build@v1
+        with:
+          rosdistro: ${{ matrix.rosdistro }}
+          target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
+          build-depends-repos: ${{ matrix.build-depends-repos }}
+          token: ${{ secrets.UNITTEST_WORKFLOW_TOKEN }}
+
+      - name: Test
+        if: ${{ steps.get-self-packages.outputs.self-packages != '' }}
+        id: test
+        uses: autowarefoundation/autoware-github-actions/colcon-test@v1
+        with:
+          rosdistro: ${{ matrix.rosdistro }}
+          target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
+          build-depends-repos: ${{ matrix.build-depends-repos }}
+          token: ${{ secrets.UNITTEST_WORKFLOW_TOKEN }}
+
+      ### # Uncomment here, to use CodeCov
+      ### - name: Upload coverage to CodeCov
+      ###   if: ${{ steps.test.outputs.coverage-report-files != '' }}
+      ###   uses: codecov/codecov-action@v5
+      ###   with:
+      ###     files: ${{ steps.test.outputs.coverage-report-files }}
+      ###     token: ${{ secrets.CODECOV_TOKEN }}
+      ###     fail_ci_if_error: false
+      ###     verbose: true
+      ###     flags: total
+
+      - name: Show disk space after the tasks
+        run: df -h


### PR DESCRIPTION
Another CI workflow using with Autoware Foundation's GitHub actions.
The run result can be seen: https://github.com/Futu-reADS/autoware_bridge/actions/runs/15339462802

**NOTE:** It hasn't been confirmed yet in the case that a user other than me makes "git push". (So, I want to confirm it when this pull request is merged)
Perhaps, it may fail to authenticate in the internal `vcs`, `rosdep`, or `colcon` in the Autoware Foundation's actions. If so, it might be hard to resolve for now, because:
- The autoware_bridge is a public repo, so the workflow has no authentication token to access private repos.
- The Autoware Foundation's actions don't use an SSH key to authenticate, but the token, AFAIK.

... as I wrote in the following page, 
https://futu-reco.atlassian.net/wiki/spaces/F/pages/405078018/GitHub+Actions+Workflow+-+Automatic+Unit+Tests#Additional-notes.3

In that case, we can disable the workflow for "autoware_bridge" and apply it to a private repository, such as "fault_detection". 