### PR TITLE
Fix: workaround when apt GPG key is mismatch

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -9,7 +9,7 @@ on:
   ###   - branches: [ "main" ]
   ### schedule:
   ###   - cron: 0 0 * * *
-  workflow_dispatch:
+  ### workflow_dispatch:
 
 jobs:
   build-and-test:
@@ -73,7 +73,16 @@ jobs:
       - name: Install additional packages
         run: |
           # Install dependent packages
-          sudo apt-get update -qy
+          sudo apt-get update -qy || {
+            # It may fail by an outdated GPG key
+            for F in $(grep -FlR 'http://packages.ros.org/ros2/ubuntu' /etc/apt/sources.list.d/); do
+              sudo rm -vf "$F"
+            done
+            sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" \
+            | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+            sudo apt-get update -y
+          }
           sudo apt-get install -y \
             ros-humble-autoware-common-msgs \
             libunwind-dev \

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -16,7 +16,7 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   # But it can work only if it exists in the default branch
-  workflow_dispatch:
+  ### workflow_dispatch:
 
 jobs:
   run-all-unit-tests:


### PR DESCRIPTION
- If `apt-get update` fails, update the GPG key.
- Disabling `workflow_dispatch` event (because it is a public repo).

The actual testing step fails continuously but the `apt-get update` step passed. ("Install additional packages")
https://github.com/Futu-reADS/autoware_bridge/actions/runs/15437554964/job/43447363359

The result of the commands in the case that the apt key of ROS is unmatched, see following. It was done with commenting out the first `apt-get update`. (there would be no way to reproduce)
https://github.com/Futu-reADS/autoware_bridge/actions/runs/15434901934/job/43439287556

Both of the logs fail at `RoutePlanningTest.TestRoutePlanningFailure` in the "Test" step of the workflow.
It seems to finish in 7ms when it is occasionally successful, but it appears to stall here in these logs.

